### PR TITLE
[FLINK-22472][filesystem] close file of partition when partition is committable

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -318,7 +318,13 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                             parallelism);
         } else {
             writerStream =
-                    StreamingSink.writer(dataStream, bucketCheckInterval, builder, parallelism);
+                    StreamingSink.writer(
+                            dataStream,
+                            bucketCheckInterval,
+                            builder,
+                            parallelism,
+                            getPartitionKeys(),
+                            conf);
         }
 
         return StreamingSink.sink(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -256,7 +256,7 @@ public class Bucket<IN, BucketID> {
                         + outputFileConfig.getPartSuffix());
     }
 
-    private InProgressFileWriter.PendingFileRecoverable closePartFile() throws IOException {
+    InProgressFileWriter.PendingFileRecoverable closePartFile() throws IOException {
         InProgressFileWriter.PendingFileRecoverable pendingFileRecoverable = null;
         if (inProgressPart != null) {
             pendingFileRecoverable = inProgressPart.closeForCommit();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -339,6 +339,13 @@ public class Buckets<IN, BucketID> {
         }
     }
 
+    public void closePartFileForBucket(BucketID bucketID) throws Exception {
+        Bucket<IN, BucketID> bucket = activeBuckets.get(bucketID);
+        if (bucket != null) {
+            bucket.closePartFile();
+        }
+    }
+
     public void close() {
         if (activeBuckets != null) {
             activeBuckets.values().forEach(Bucket::disposePartFile);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -259,7 +259,12 @@ public class FileSystemTableSink extends AbstractFileSystemTable
         } else {
             writerStream =
                     StreamingSink.writer(
-                            dataStream, bucketCheckInterval, bucketsBuilder, parallelism);
+                            dataStream,
+                            bucketCheckInterval,
+                            bucketsBuilder,
+                            parallelism,
+                            partitionKeys,
+                            tableOptions);
         }
 
         return StreamingSink.sink(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
@@ -52,11 +52,11 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
 
     // --------------------------- runtime fields -----------------------------
 
-    private transient Buckets<IN, String> buckets;
+    protected transient Buckets<IN, String> buckets;
 
     private transient StreamingFileSinkHelper<IN> helper;
 
-    private transient long currentWatermark;
+    protected transient long currentWatermark;
 
     public AbstractStreamingWriter(
             long bucketCheckInterval,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
@@ -62,9 +62,11 @@ public class StreamingSink {
             StreamingFileSink.BucketsBuilder<
                             T, String, ? extends StreamingFileSink.BucketsBuilder<T, String, ?>>
                     bucketsBuilder,
-            int parallelism) {
+            int parallelism,
+            List<String> partitionKeys,
+            Configuration conf) {
         StreamingFileWriter<T> fileWriter =
-                new StreamingFileWriter<>(bucketCheckInterval, bucketsBuilder);
+                new StreamingFileWriter<>(bucketCheckInterval, bucketsBuilder, partitionKeys, conf);
         return inputStream
                 .transform(
                         StreamingFileWriter.class.getSimpleName(),

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
@@ -19,11 +19,14 @@
 package org.apache.flink.table.filesystem.stream;
 
 import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
+import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
+import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
@@ -31,6 +34,7 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.filesystem.FileSystemTableSink;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,14 +45,27 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_DELAY;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_TRIGGER;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE;
 
 /** Test for {@link StreamingFileWriter}. */
 public class StreamingFileWriterTest {
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private final OutputFileConfig outputFileConfig = OutputFileConfig.builder().build();
+    private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
     private Path path;
 
@@ -147,6 +164,156 @@ public class StreamingFileWriterTest {
         }
     }
 
+    @Test
+    public void testCommitFileWhenPartitionIsCommittableByProcessTime() throws Exception {
+        // the rolling policy is not to roll file by filesize and roll file after one day,
+        // it can ensure the file can be closed only when the partition is committable in this test.
+        FileSystemTableSink.TableRollingPolicy tableRollingPolicy =
+                new FileSystemTableSink.TableRollingPolicy(
+                        false, Long.MAX_VALUE, Duration.ofDays(1).toMillis());
+        List<String> partitionKeys = Collections.singletonList("d");
+        // commit delay is 1 second with process commit trigger
+        Configuration conf = getProcTimeCommitTriggerConf(Duration.ofSeconds(1).toMillis());
+        OperatorSubtaskState state;
+        long currentTimeMillis = System.currentTimeMillis();
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeEmptyState();
+            harness.open();
+            harness.setProcessingTime(currentTimeMillis);
+            harness.processElement(row("1"), 0);
+            harness.processElement(row("2"), 0);
+            state = harness.snapshot(1, 1);
+            harness.processElement(row("3"), 0);
+            harness.processElement(row("1"), 0);
+            harness.notifyOfCompletedCheckpoint(1);
+            // assert files aren't committed in {1, 2} partitions
+            Assert.assertFalse(isPartitionFileCommitted("1", 0, 0));
+            Assert.assertFalse(isPartitionFileCommitted("2", 0, 1));
+        }
+
+        // first retry
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+            harness.processElement(row("3"), 0);
+            // simulate waiting for 2 seconds, now partition is committable
+            currentTimeMillis += Duration.ofSeconds(2).toMillis();
+            harness.setProcessingTime(currentTimeMillis);
+            harness.processElement(row("1"), 0);
+            harness.snapshot(2, 2);
+            harness.notifyOfCompletedCheckpoint(2);
+            // now files in {1, 2, 3} partitions should be committed
+            // assert files are committed
+            Assert.assertTrue(isPartitionFileCommitted("1", 0, 0));
+            Assert.assertTrue(isPartitionFileCommitted("2", 0, 1));
+            Assert.assertTrue(isPartitionFileCommitted("3", 0, 2));
+            harness.processElement(row("3"), 0);
+            state = harness.snapshot(3, 3);
+        }
+
+        // second retry
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+
+            harness.processElement(row("4"), 0);
+            harness.processElement(row("4"), 0);
+            harness.snapshot(4, 4);
+            harness.processElement(row("5"), 0);
+            harness.endInput();
+            // assert files in all partition have been committed
+            // the file for partition 3 will be a newer one with partCounter 3
+            // for previous in-progress file has closed in checkpoint 2
+            Assert.assertTrue(isPartitionFileCommitted("3", 0, 3));
+            Assert.assertTrue(isPartitionFileCommitted("4", 0, 4));
+            Assert.assertTrue(isPartitionFileCommitted("5", 0, 5));
+        }
+    }
+
+    @Test
+    public void testCommitFileWhenPartitionIsCommittableByPartitionTime() throws Exception {
+        // the rolling policy is not to roll file by filesize and roll file after one day,
+        // it can ensure the file can be closed only when the partition is committable in this test.
+        FileSystemTableSink.TableRollingPolicy tableRollingPolicy =
+                new FileSystemTableSink.TableRollingPolicy(
+                        false, Long.MAX_VALUE, Duration.ofDays(1).toMillis());
+        List<String> partitionKeys = Collections.singletonList("d");
+        // commit delay is 1 day with partition commit trigger
+        Configuration conf = getPartitionCommitTriggerConf(Duration.ofDays(1).toMillis());
+
+        long currentTimeMillis = System.currentTimeMillis();
+
+        Date nextYear = new Date(currentTimeMillis + Duration.ofDays(365).toMillis());
+        String nextYearPartition = "d=" + dateFormat.format(nextYear);
+        Date yesterday = new Date(currentTimeMillis - Duration.ofDays(1).toMillis());
+        String yesterdayPartition = "d=" + dateFormat.format(yesterday);
+        Date today = new Date(currentTimeMillis);
+        String todayPartition = "d=" + dateFormat.format(today);
+        Date tomorrow = new Date(currentTimeMillis + Duration.ofDays(1).toMillis());
+        String tomorrowPartition = "d=" + dateFormat.format(tomorrow);
+
+        OperatorSubtaskState state;
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeEmptyState();
+            harness.open();
+            harness.setProcessingTime(currentTimeMillis);
+            harness.processElement(row(yesterdayPartition), 0);
+            harness.processElement(row(todayPartition), 0);
+            harness.processWatermark(currentTimeMillis);
+            state = harness.snapshot(1, 1);
+            harness.processElement(row(todayPartition), 0);
+            harness.notifyOfCompletedCheckpoint(1);
+            // assert yesterday partition file is committed
+            Assert.assertTrue(isPartitionFileCommitted(yesterdayPartition, 0, 0));
+            // assert today partition file isn't committed
+            Assert.assertFalse(isPartitionFileCommitted(todayPartition, 0, 1));
+        }
+
+        // first retry
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+            harness.processElement(row(tomorrowPartition), 0);
+            harness.processElement(row(todayPartition), 0);
+            // simulate waiting for 1 day
+            currentTimeMillis += Duration.ofDays(1).toMillis();
+            harness.processWatermark(currentTimeMillis);
+            harness.snapshot(2, 2);
+            harness.notifyOfCompletedCheckpoint(2);
+            // assert today partition file is committed
+            Assert.assertTrue(isPartitionFileCommitted(todayPartition, 0, 1));
+            // assert tomorrow partition file isn't committed
+            Assert.assertFalse(isPartitionFileCommitted(tomorrowPartition, 0, 2));
+            harness.processElement(row(tomorrowPartition), 0);
+            state = harness.snapshot(3, 3);
+            harness.processElement(row(nextYearPartition), 0);
+        }
+
+        // second retry
+        try (OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
+                create(tableRollingPolicy, partitionKeys, conf)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+
+            harness.processElement(row(nextYearPartition), 0);
+            harness.endInput();
+            // assert files in all partition have been committed
+            Assert.assertTrue(isPartitionFileCommitted(tomorrowPartition, 0, 2));
+            Assert.assertTrue(isPartitionFileCommitted(nextYearPartition, 0, 3));
+        }
+    }
+
     private static RowData row(String s) {
         return GenericRowData.of(StringData.fromString(s));
     }
@@ -159,6 +326,16 @@ public class StreamingFileWriterTest {
     }
 
     private OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> create()
+            throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "process-time");
+        return create(OnCheckpointRollingPolicy.build(), new ArrayList<>(), configuration);
+    }
+
+    private OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> create(
+            RollingPolicy<RowData, String> rollingPolicy,
+            List<String> partitionKeys,
+            Configuration conf)
             throws Exception {
         StreamingFileWriter<RowData> writer =
                 new StreamingFileWriter<>(
@@ -186,10 +363,43 @@ public class StreamingFileWriterTest {
                                                 return SimpleVersionedStringSerializer.INSTANCE;
                                             }
                                         })
-                                .withRollingPolicy(OnCheckpointRollingPolicy.build()));
+                                .withRollingPolicy(rollingPolicy),
+                        partitionKeys,
+                        conf);
         OneInputStreamOperatorTestHarness<RowData, PartitionCommitInfo> harness =
                 new OneInputStreamOperatorTestHarness<>(writer, 1, 1, 0);
         harness.getStreamConfig().setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
         return harness;
+    }
+
+    private Configuration getPartitionCommitTriggerConf(long commitDelay) {
+        Configuration configuration = new Configuration();
+        configuration.setString(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
+        configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "partition-time");
+        configuration.setLong(SINK_PARTITION_COMMIT_DELAY.key(), commitDelay);
+        configuration.setString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE.key(), "UTC");
+        return configuration;
+    }
+
+    private Configuration getProcTimeCommitTriggerConf(long commitDelay) {
+        Configuration configuration = new Configuration();
+        configuration.setString(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
+        configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "process-time");
+        configuration.setLong(SINK_PARTITION_COMMIT_DELAY.key(), commitDelay);
+        configuration.setString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE.key(), "UTC");
+        return configuration;
+    }
+
+    private boolean isPartitionFileCommitted(String partition, int subtaskIndex, int partCounter) {
+        java.nio.file.Path bucketPath = Paths.get(path.getPath(), partition);
+        String fileName =
+                outputFileConfig.getPartPrefix()
+                        + '-'
+                        + subtaskIndex
+                        + '-'
+                        + partCounter
+                        + outputFileConfig.getPartSuffix();
+        java.nio.file.Path filePath = bucketPath.resolve(fileName);
+        return filePath.toFile().exists();
     }
 }


### PR DESCRIPTION
…ommittable to fix the issue that although partition has committed, the file in this partition is unready.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
